### PR TITLE
DB SQL creates schema when imported

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@
 20. On the left sidebar, under the "Administration" tab, select "Data Import/Restore"
 21. On the localhost Data Import page, select the "Import from Self-Contained File" radio button and set the file path to "<path>/XAMPP/htdocs/BatteshipWeb/battleship/database/Battleships.sql"
 22. Click Start Import
-23. Complete the steps in the Run section to test that everything is set up correctly
+23. Refresh the Schemas on the left side and confirm that a schema called 'battleship' was created.
+24. Complete the steps in the Run section to test that everything is set up correctly
 
 ## Run
 1. Start XAMPP Apache & MySQL servers

--- a/battleship/database/Battleships.sql
+++ b/battleship/database/Battleships.sql
@@ -1,13 +1,15 @@
--- MariaDB dump 10.19  Distrib 10.4.32-MariaDB, for Win64 (AMD64)
+CREATE DATABASE  IF NOT EXISTS `battleship` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci */;
+USE `battleship`;
+-- MySQL dump 10.13  Distrib 8.0.36, for Win64 (x86_64)
 --
 -- Host: 127.0.0.1    Database: battleship
 -- ------------------------------------------------------
--- Server version	10.4.32-MariaDB
+-- Server version	5.5.5-10.4.32-MariaDB
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8 */;
+/*!50503 SET NAMES utf8 */;
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
@@ -21,7 +23,7 @@
 
 DROP TABLE IF EXISTS `entity_games`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `entity_games` (
   `id_game` mediumint(7) NOT NULL,
   PRIMARY KEY (`id_game`)
@@ -44,7 +46,7 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `entity_players`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `entity_players` (
   `id_player` mediumint(7) NOT NULL,
   `board_ships` varchar(2000) DEFAULT NULL,
@@ -71,13 +73,13 @@ INSERT INTO `entity_players` VALUES (1,'{JSON}','{JSON}','1',NULL,NULL,NULL,NULL
 UNLOCK TABLES;
 
 --
--- Table structure for table `entity_user`
+-- Table structure for table `entity_users`
 --
 
-DROP TABLE IF EXISTS `entity_user`;
+DROP TABLE IF EXISTS `entity_users`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `entity_user` (
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `entity_users` (
   `id_user` mediumint(7) NOT NULL AUTO_INCREMENT,
   `username` varchar(50) DEFAULT NULL,
   `first_name` varchar(50) DEFAULT NULL,
@@ -86,17 +88,17 @@ CREATE TABLE `entity_user` (
   `email` varchar(50) DEFAULT NULL,
   `password` varchar(16) DEFAULT NULL,
   PRIMARY KEY (`id_user`)
-) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
--- Dumping data for table `entity_user`
+-- Dumping data for table `entity_users`
 --
 
-LOCK TABLES `entity_user` WRITE;
-/*!40000 ALTER TABLE `entity_user` DISABLE KEYS */;
-INSERT INTO `entity_user` VALUES (1,'hansintheair','Hannes','M.','Ziegler','hansintheair@email.com','hanssafepwd#1'),(2,'mathewnex12','Mathew',NULL,NULL,'mathew@email.com','mathsafepws#1');
-/*!40000 ALTER TABLE `entity_user` ENABLE KEYS */;
+LOCK TABLES `entity_users` WRITE;
+/*!40000 ALTER TABLE `entity_users` DISABLE KEYS */;
+INSERT INTO `entity_users` VALUES (1,'hansintheair','Hannes','M.','Ziegler','hansintheair@email.com','hanssafepwd#1'),(2,'mathewnex12','Mathew',NULL,NULL,'mathew@email.com','mathsafepws#1'),(3,NULL,NULL,NULL,NULL,'anthonyb@whatever.com','$2y$10$gfu55oHnA');
+/*!40000 ALTER TABLE `entity_users` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
@@ -105,7 +107,7 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `xref_games_players`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `xref_games_players` (
   `id_game_players` mediumint(7) NOT NULL,
   `id_game` mediumint(7) DEFAULT NULL,
@@ -130,7 +132,7 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `xref_users_games`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `xref_users_games` (
   `id_user_games` mediumint(7) NOT NULL AUTO_INCREMENT,
   `id_user` mediumint(7) DEFAULT NULL,
@@ -148,10 +150,6 @@ LOCK TABLES `xref_users_games` WRITE;
 INSERT INTO `xref_users_games` VALUES (1,1,1),(2,2,2);
 /*!40000 ALTER TABLE `xref_users_games` ENABLE KEYS */;
 UNLOCK TABLES;
-
---
--- Dumping routines for database 'battleship'
---
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
@@ -162,4 +160,4 @@ UNLOCK TABLES;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2024-05-18 15:33:00
+-- Dump completed on 2024-05-20 12:44:58


### PR DESCRIPTION
When you import the SQL into mysql workbench, it should now create the schema called 'battleship' which is required to connect to the DB.

Added small DB detail to the readme

Fixed small typo in entity_users table